### PR TITLE
Fixed CorsMiddleware::beforeHandleRoute

### DIFF
--- a/src/PhalconApi/Middleware/CorsMiddleware.php
+++ b/src/PhalconApi/Middleware/CorsMiddleware.php
@@ -131,23 +131,33 @@ class CorsMiddleware extends Plugin implements MiddlewareInterface
             $origin = $this->request->getHeader('Origin');
             $originDomain = $origin ? parse_url($origin, PHP_URL_HOST) : null;
 
-            if ($originDomain) {
+            if (!$originDomain) {
+                return;
+            }
+            
+            $allowed = false;
 
-                $allowed = in_array($allowedOrigin, $this->_allowedOrigins);
+            foreach ($this->_allowedOrigins as $allowedOrigin) {
 
-                if (false === $allowed) {
-                    // Parse wildcards
-                    $expression = '/^' . str_replace('\*', '(.+)', preg_quote($allowedOrigin, '/')) . '$/';
-                    if (preg_match($expression, $originDomain) == 1) {
+                // First try exact domain
+                if ($originDomain == $allowedOrigin) {
 
-                        $allowed = true;
-                    }
+                    $allowed = true;
+                    break;
                 }
+                
+                // Parse wildcards
+                $expression = '/^' . str_replace('\*', '(.+)', preg_quote($allowedOrigin, '/')) . '$/i';
+                if (preg_match($expression, $originDomain) == 1) {
 
-                if ($allowed) {
-
-                    $originValue = $origin;
+                    $allowed = true;
+                    break;
                 }
+            }
+                
+            if ($allowed) {
+
+                $originValue = $origin;
             }
         }
 


### PR DESCRIPTION
After the changes made by @thecharge in #1 
the `CorsMiddleware::beforeHandleRoute` is completely broken.

This is obvious because the `$allowedOrigin` variable is undefined now.

Note: I've added the **`i`** modifier to the regular expression.
 
Refs: https://github.com/redound/phalcon-api/commit/44031455fa299d0f87861a68adb047dcb7728b79#diff-e0f68aa0c2eadb45e6b357a76fa5aa50

/ cc: @bblok11, @olivierandriessen 